### PR TITLE
fix: Fix OpenAI profile configuration to prevent bean conflicts

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -104,6 +104,11 @@ spring:
     model:
       chat: openai
       embedding: openai
+    ollama:
+      chat:
+        enabled: false
+      embedding:
+        enabled: false
     openai:
       api-key: ${OPENAI_API_KEY}
       chat:


### PR DESCRIPTION
## Description
When running the application with the `openai` profile as per the documentation, a `BeanCreationException` occurs due to conflicts with Ollama auto-configuration.

This PR fixes the issue by explicitly disabling Ollama chat and embedding capabilities within the `openai` profile configuration.

## Changes
- Explicitly set `spring.ai.ollama.chat.enabled` and `embedding.enabled` to `false` in the `openai` profile.
- Ensured OpenAI options are correctly configured.

## How to test
1. Set the profile to `openai` in `application.yml` or via command line arguments.
2. Run the application.
3. Verify that the application starts successfully without bean conflicts.